### PR TITLE
Additional files after initial selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,256 +1,252 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>WACZ Uploader</title>
-    <link rel="stylesheet" href="./styles.css">
-    <link
-      rel="preload"
-      as="image"
-      href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg">
-    <link
-      rel="preload"
-      as="image"
-      href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/exclamation-circle-fill.svg">
-    <link
-      rel="preload"
-      as="image"
-      href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-circle-fill.svg">
-  </head>
-  <body class="app-container">
-    <div class="app">
-      <h1 class="heading title">WACZ Uploader</h1>
-      <main class="panel scrollable">
-        <div id="appRoot" class="app-content app-content-2-col scroll-content">
-          <div class="app-content-header card">
-            <div class="card-header">
-              <h2 class="heading subtitle">
-                Create and share a collection of web archives with IPFS!
-              </h2>
-            </div>
-            <div class="card-body">
-              <p class="text">Create an interactive, publicly accessible collection of archived webpages. The generated gallery will
-                be available immediately in your browser, and in the browsers of tomorrow with IPFS — a peer-to-peer protocol that
-                delivers files based on their contents.</p>
-              <p class="text">Never archived a website before? Try it with
-                <a class="primary" href="https://express.archiveweb.page" target="_blank">ArchiveWeb.Page</a>!</p>
-            </div>
-            <div class="card-footer help-text">
-              <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
-                <sl-icon class="icon" src="https://webrecorder.net/assets/wr-logo.svg"></sl-icon>
-                <span class="label">Created by Webrecorder</span>
-              </a>
-              <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
-                <span class="label">Source code</span>
-                <sl-icon
-                  class="icon"
-                  src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/github.svg"></sl-icon>
-              </a>
-            </div>
-          </div>
-          <div class="file-upload-container">
-            <label id="dropzone" class="file-drag-drop">
-              <svg
-                class="file-upload-border"
-                xmlns="http://www.w3.org/2000/svg"
-                text-rendering="geometricPrecision"
-                shape-rendering="geometricPrecision"
-                height="100%"
-                width="100%"
-                viewbox="0 0 460 468">
-                <rect
-                  class="animate-border"
-                  transform="translate(2,2)"
-                  stroke="#0366d6"
-                  width="456"
-                  height="464"
-                  fill="none"
-                  stroke-width="4"
-                  stroke-linecap="round"
-                  rx="8"
-                  stroke-dasharray="24 24"
-                  stroke-dashoffset="0"/>
-              </svg>
-              <sl-animation name="pulse" iterations="1" playback-rate="2">
-                <div class="dropzone-content">
-                  <div class="dropzone-label">
-                    <p class="error-message hidden">
-                      No valid web archive files selected.
-                    </p>
-                    Click here or drop some files.
-                  </div>
-                  <p class="help-text">
-                    Multiple .wacz files will be combined into a single browsable collection, 100MB size limit per file.
-                  </p>
-                  <input type="file" id="fileInput" class="file-input" multiple accept=".wacz,.warc"/>
-                </div>
-              </sl-animation>
-            </label>
-          </div>
-        </div>
-      </main>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>WACZ Uploader</title>
+<link rel="stylesheet" href="./styles.css">
+<link rel="preload" as="image" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg">
+<link rel="preload" as="image" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/exclamation-circle-fill.svg">
+<link rel="preload" as="image" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-circle-fill.svg">
+</head>
+<body class="app-container">
+<div class="app">
+<h1 class="heading title">WACZ Uploader</h1>
+<main class="panel scrollable">
+  <div id="appRoot" class="app-content app-content-2-col scroll-content">
+    <div class="app-content-header card">
+      <div class="card-header">
+        <h2 class="heading subtitle">
+          Create and share a collection of web archives with IPFS!
+        </h2>
+      </div>
+      <div class="card-body">
+        <p class="text">Create an interactive, publicly accessible collection of archived webpages. The generated gallery will
+          be available immediately in your browser, and in the browsers of tomorrow with IPFS — a peer-to-peer protocol that
+          delivers files based on their contents.</p>
+        <p class="text">Never archived a website before? Try it with
+          <a class="primary" href="https://express.archiveweb.page" target="_blank">ArchiveWeb.Page</a>!</p>
+      </div>
+      <div class="card-footer help-text">
+        <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
+          <sl-icon class="icon" src="https://webrecorder.net/assets/wr-logo.svg"></sl-icon>
+          <span class="label">Created by Webrecorder</span>
+        </a>
+        <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
+          <span class="label">Source code</span>
+          <sl-icon
+            class="icon"
+            src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/github.svg"></sl-icon>
+        </a>
+      </div>
     </div>
-    <div id="debug" class="hidden">
-      <details>
-        <summary>DEBUG: Past uploads:</summary>
-        <section id="resultzone"></section>
-      </details>
-      <details>
-        <summary>DEBUG: status log</summary>
-        <section id="statuslog"></section>
-      </details>
-    </div>
-    <template id="uploadProgressScreen">
-      <section class="panel card">
-        <div class="card-header">
-          <h2 class="heading subtitle">Add File Information</h2>
-          <h3 class="text file-list-heading">Files</h3>
-        </div>
-        <div class="card-body scrollable">
-          <div class="scroll-content">
-            <ul class="file-list"></ul>
-          </div>
-        </div>
-        <div class="card-footer">
-          <div class="error-message"></div>
-          <button class="continue-btn primary" autocomplete="false">Continue</button>
-        </div>
-      </section>
-      <section class="panel scrollable">
-        <div class="file-detail-list scroll-content"></div>
-      </section>
-    </template>
-    <template id="fileListItem">
-      <li class="file-list-item" data-file-name="">
-        <div class="file-info" role="button">
-          <div class="status"></div>
-          <div class="name"></div>
-          <sl-format-bytes class="size help-text" value=""></sl-format-bytes>
-          <button class="delete-btn icon-btn danger">
-            <sl-icon
-              class="icon"
-              src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg"></sl-icon>
-          </button>
-        </div>
-      </li>
-    </template>
-    <template id="fileDetailItem">
-      <section class="file-detail" data-file-name="">
-        <header class="file-detail-header">
-          <h4 class="heading subtitle name"></h4>
-          <button class="edit-btn icon-btn default">
-            <sl-icon
-              class="icon"
-              src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/pencil.svg"></sl-icon>
-          </button>
-        </header>
-        <form class="name-form field hidden" autocomplete="off">
-          <input class="name-input" value=""/>
-          <button type="submit" class="save-btn icon-btn secondary">
-            <sl-icon
-              class="icon"
-              src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-lg.svg"></sl-icon>
-          </button>
-        </form>
-        <label class="field">
-          <div class="label-text">Description</div>
-          <textarea placeholder="Add a short explanation of the file's contents"></textarea>
-        </label>
-      </section>
-    </template>
-    <template id="incompleteWarningScreen">
-      <section class="panel card incomplete-warning">
-        <div class="card-body incomplete-message">
-          <div>
-            <p class="heading">Some files didn’t upload properly</p>
-            <p class="text">Are you sure you want to continue?</p>
-            <p class="text">Incomplete uploads will not be present in the final website.</p>
-          </div>
-        </div>
-        <div class="card-footer">
-          <button class="back-btn default">Go Back</button>
-          <button class="continue-btn primary">Continue</button>
-        </div>
-      </section>
-    </template>
-    <template id="creatingSiteScreen">
-      <section class="panel card">
-        <div class="card-body upload-status-message">
-          <div>
-            <sl-spinner></sl-spinner>
-            <div class="heading">Creating Website</div>
-            <div class="site-status help-text">Uploading to IPFS...</div>
-          </div>
-        </div>
-      </section>
-    </template>
-    <template id="creatingSiteErrorScreen">
-      <section class="panel card">
-        <div class="card-body upload-status-message">
-          <div>
-            <p class="text">
-              Couldn't create website due to error:
+    <div class="file-upload-container">
+      <label id="dropzone" class="file-drag-drop">
+        <svg
+          class="file-upload-border"
+          xmlns="http://www.w3.org/2000/svg"
+          text-rendering="geometricPrecision"
+          shape-rendering="geometricPrecision"
+          height="100%"
+          width="100%"
+          viewbox="0 0 460 468">
+          <rect
+            class="animate-border"
+            transform="translate(2,2)"
+            stroke="#0366d6"
+            width="456"
+            height="464"
+            fill="none"
+            stroke-width="4"
+            stroke-linecap="round"
+            rx="8"
+            stroke-dasharray="24 24"
+            stroke-dashoffset="0"/>
+        </svg>
+        <sl-animation name="pulse" iterations="1" playback-rate="2">
+          <div class="dropzone-content">
+            <div class="dropzone-label">
+              <p class="error-message hidden">
+                No valid web archive files selected.
+              </p>
+              Click here or drop some files.
+            </div>
+            <p class="help-text">
+              Multiple .wacz files will be combined into a single browsable collection, 100MB size limit per file.
             </p>
-            <div class="error-message"></div>
-            <button class="retry-btn primary">Retry</button>
+            <input type="file" class="file-input" multiple accept=".wacz,.warc"/>
           </div>
+        </sl-animation>
+      </label>
+    </div>
+  </div>
+</main>
+</div>
+<div id="debug" class="hidden">
+  <details>
+    <summary>DEBUG: Past uploads:</summary>
+    <section id="resultzone"></section>
+  </details>
+  <details>
+    <summary>DEBUG: status log</summary>
+    <section id="statuslog"></section>
+  </details>
+</div>
+<template id="uploadProgressScreen">
+  <section class="panel card">
+    <div class="card-header">
+      <h2 class="heading subtitle">Add File Information</h2>
+      <h3 class="text file-list-heading">Files</h3>
+    </div>
+    <div class="card-body scrollable">
+      <div class="scroll-content">
+        <ul class="file-list"></ul>
+      </div>
+    </div>
+    <div class="card-footer">
+      <div>
+        <label class="file-input-label">
+          Add more files <input type="file" class="file-input" multiple accept=".wacz,.warc"/>
+        </label>
+        <div class="error-message"></div>
+      </div>
+      <button class="continue-btn primary" autocomplete="false">Continue</button>
+    </div>
+  </section>
+  <section class="panel scrollable">
+    <div class="file-detail-list scroll-content"></div>
+  </section>
+</template>
+<template id="fileListItem">
+  <li class="file-list-item" data-file-name="">
+    <div class="file-info" role="button">
+      <div class="status"></div>
+      <div class="name"></div>
+      <sl-format-bytes class="size help-text" value=""></sl-format-bytes>
+      <button class="delete-btn icon-btn danger">
+        <sl-icon
+          class="icon"
+          src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg"></sl-icon>
+      </button>
+    </div>
+  </li>
+</template>
+<template id="fileDetailItem">
+  <section class="file-detail" data-file-name="">
+    <header class="file-detail-header">
+      <h4 class="heading subtitle name"></h4>
+      <button class="edit-btn icon-btn default">
+        <sl-icon
+          class="icon"
+          src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/pencil.svg"></sl-icon>
+      </button>
+    </header>
+    <form class="name-form field hidden" autocomplete="off">
+      <input class="name-input" value=""/>
+      <button type="submit" class="save-btn icon-btn secondary">
+        <sl-icon
+          class="icon"
+          src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-lg.svg"></sl-icon>
+      </button>
+    </form>
+    <label class="field">
+      <div class="label-text">Description</div>
+      <textarea placeholder="Add a short explanation of the file's contents"></textarea>
+    </label>
+  </section>
+</template>
+<template id="incompleteWarningScreen">
+  <section class="panel card incomplete-warning">
+    <div class="card-body incomplete-message">
+      <div>
+        <p class="heading">Some files didn’t upload properly</p>
+        <p class="text">Are you sure you want to continue?</p>
+        <p class="text">Incomplete uploads will not be present in the final website.</p>
+      </div>
+    </div>
+    <div class="card-footer">
+      <button class="back-btn default">Go Back</button>
+      <button class="continue-btn primary">Continue</button>
+    </div>
+  </section>
+</template>
+<template id="creatingSiteScreen">
+  <section class="panel card">
+    <div class="card-body upload-status-message">
+      <div>
+        <sl-spinner></sl-spinner>
+        <div class="heading">Creating Website</div>
+        <div class="site-status help-text">Uploading to IPFS...</div>
+      </div>
+    </div>
+  </section>
+</template>
+<template id="creatingSiteErrorScreen">
+  <section class="panel card">
+    <div class="card-body upload-status-message">
+      <div>
+        <p class="text">
+          Couldn't create website due to error:
+        </p>
+        <div class="error-message"></div>
+        <button class="retry-btn primary">Retry</button>
+      </div>
+    </div>
+    <div class="card-footer">
+      <button class="back-btn default">Go Back</button>
+    </div>
+  </section>
+</template>
+<template id="createSiteDoneScreen">
+  <section class="panel card">
+    <div class="card-body upload-status-message">
+      <div>
+        <div class="heading subtitle">Success!</div>
+        <p class="text">Your archive is available at:</p>
+        <div class="heading">
+          <a class="site-url primary" href="#" target="_blank" rel="noreferrer noopener"></a>
         </div>
-        <div class="card-footer">
-          <button class="back-btn default">Go Back</button>
+        <div>
+          <button class="restart-btn primary">Create Another</button>
         </div>
-      </section>
-    </template>
-    <template id="createSiteDoneScreen">
-      <section class="panel card">
-        <div class="card-body upload-status-message">
-          <div>
-            <div class="heading subtitle">Success!</div>
-            <p class="text">Your archive is available at:</p>
-            <div class="heading">
-              <a class="site-url primary" href="#" target="_blank" rel="noreferrer noopener"></a>
-            </div>
-            <div>
-              <button class="restart-btn primary">Create Another</button>
-            </div>
-          </div>
-        </div>
-      </section>
-    </template>
-    <template id="settingsPanel">
-      <section class="panel card">
-        <div class="card-header">
-          <h3 class="heading subtitle">Back-End Settings</h3>
-        </div>
-        <div class="card-body scrollable">
-          <form class="scroll-content">
-            <label class="field">
-              <div class="label-text">IPFS Backend</div>
-              <select>
-                <option value="">Webrecorder Default</option>
-              </select>
-            </label>
-            <label class="field">
-              <div class="label-text">Custom Web3.Storage Token</div>
-              <input placeholder="[EXAMPLE]"/>
-            </label>
-            <label class="field">
-              <div class="label-text">Custom Estuary Token</div>
-              <input placeholder="[EXAMPLE]"/>
-            </label>
-            <label class="field">
-              <div class="label-text">Personal Kubo Daemon URL</div>
-              <input placeholder="[EXAMPLE]"/>
-            </label>
-          </form>
-        </div>
-        <div class="card-footer">
-          <button class="default">Cancel</button>
-          <button class="primary">Save Settings</button>
-        </div>
-      </section>
-    </template>
-    <script type="module" src="./vendor.js"></script>
-    <script type="module" src="./bundle.js"></script>
-  </body>
+      </div>
+    </div>
+  </section>
+</template>
+<template id="settingsPanel">
+  <section class="panel card">
+    <div class="card-header">
+      <h3 class="heading subtitle">Back-End Settings</h3>
+    </div>
+    <div class="card-body scrollable">
+      <form class="scroll-content">
+        <label class="field">
+          <div class="label-text">IPFS Backend</div>
+          <select>
+            <option value="">Webrecorder Default</option>
+          </select>
+        </label>
+        <label class="field">
+          <div class="label-text">Custom Web3.Storage Token</div>
+          <input placeholder="[EXAMPLE]"/>
+        </label>
+        <label class="field">
+          <div class="label-text">Custom Estuary Token</div>
+          <input placeholder="[EXAMPLE]"/>
+        </label>
+        <label class="field">
+          <div class="label-text">Personal Kubo Daemon URL</div>
+          <input placeholder="[EXAMPLE]"/>
+        </label>
+      </form>
+    </div>
+    <div class="card-footer">
+      <button class="default">Cancel</button>
+      <button class="primary">Save Settings</button>
+    </div>
+  </section>
+</template>
+<script type="module" src="./vendor.js"></script>
+<script type="module" src="./bundle.js"></script>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,243 +1,256 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<title>WACZ Uploader</title>
-<link rel="stylesheet" href="./styles.css">
-<link rel="preload" as="image" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg">
-<link rel="preload" as="image" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/exclamation-circle-fill.svg">
-<link rel="preload" as="image" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-circle-fill.svg">
-</head>
-<body class="app-container">
-<div class="app">
-<h1 class="heading title">WACZ Uploader</h1>
-<main class="panel scrollable">
-  <div id="appRoot" class="app-content app-content-2-col scroll-content">
-    <div class="app-content-header card">
-      <div class="card-header">
-        <h2 class="heading subtitle">
-          Create and share a collection of web archives with IPFS!
-        </h2>
-      </div>
-      <div class="card-body">
-        <p class="text">Create an interactive, publicly accessible collection of archived webpages. The generated gallery will be available immediately in your browser, and in the browsers of tomorrow with IPFS — a peer-to-peer protocol that delivers files based on their contents.</p>
-        <p class="text">Never archived a website before? Try it with <a class="primary" href="https://express.archiveweb.page" target="_blank">ArchiveWeb.Page</a>!</p>
-      </div>
-      <div class="card-footer help-text">
-        <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
-          <sl-icon class="icon" src="https://webrecorder.net/assets/wr-logo.svg"></sl-icon>
-          <span class="label">Created by Webrecorder</span>
-        </a>
-        <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
-          <span class="label">Source code</span>
-          <sl-icon class="icon" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/github.svg"></sl-icon>
-        </a>
-      </div>
-    </div>
-    <div class="file-upload-container">
-      <label id="dropzone">
-        <svg
-          class="file-upload-border"
-          xmlns="http://www.w3.org/2000/svg"
-          text-rendering="geometricPrecision"
-          shape-rendering="geometricPrecision"
-          height="100%"
-          width="100%"
-          viewbox="0 0 460 468">
-          <rect
-            class="animate-border"
-            transform="translate(2,2)"
-            stroke="#0366d6"
-            width="456"
-            height="464"
-            fill="none"
-            stroke-width="4"
-            stroke-linecap="round"
-            rx="8"
-            stroke-dasharray="24 24"
-            stroke-dashoffset="0"/>
-        </svg>
-        <sl-animation name="pulse" iterations="1" playback-rate="2">
-          <div class="dropzone-content">
-            <div class="dropzone-label">
-              <p class="error-message hidden">
-                No valid web archive files selected.
-              </p>
-
-              Click here or drop some files.
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>WACZ Uploader</title>
+    <link rel="stylesheet" href="./styles.css">
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg">
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/exclamation-circle-fill.svg">
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-circle-fill.svg">
+  </head>
+  <body class="app-container">
+    <div class="app">
+      <h1 class="heading title">WACZ Uploader</h1>
+      <main class="panel scrollable">
+        <div id="appRoot" class="app-content app-content-2-col scroll-content">
+          <div class="app-content-header card">
+            <div class="card-header">
+              <h2 class="heading subtitle">
+                Create and share a collection of web archives with IPFS!
+              </h2>
             </div>
-            <p class="help-text">
-              Multiple .wacz files will be combined into a single browsable collection, 100MB size limit per file.
-            </p>
-            <input type="file" id="fileInput" multiple accept=".wacz,.warc"/>
+            <div class="card-body">
+              <p class="text">Create an interactive, publicly accessible collection of archived webpages. The generated gallery will
+                be available immediately in your browser, and in the browsers of tomorrow with IPFS — a peer-to-peer protocol that
+                delivers files based on their contents.</p>
+              <p class="text">Never archived a website before? Try it with
+                <a class="primary" href="https://express.archiveweb.page" target="_blank">ArchiveWeb.Page</a>!</p>
+            </div>
+            <div class="card-footer help-text">
+              <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
+                <sl-icon class="icon" src="https://webrecorder.net/assets/wr-logo.svg"></sl-icon>
+                <span class="label">Created by Webrecorder</span>
+              </a>
+              <a class="secondary" href="https://github.com/webrecorder/wacz-uploader" target="_blank" rel="noreferrer noopener">
+                <span class="label">Source code</span>
+                <sl-icon
+                  class="icon"
+                  src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/github.svg"></sl-icon>
+              </a>
+            </div>
           </div>
-        </sl-animation>
-      </label>
-    </div>
-  </div>
-</main>
-</div>
-<div id="debug" class="hidden">
-  <details>
-    <summary>DEBUG: Past uploads:</summary>
-    <section id="resultzone"></section>
-  </details>
-  <details>
-    <summary>DEBUG: status log</summary>
-    <section id="statuslog"></section>
-  </details>
-</div>
-<template id="uploadProgressScreen">
-  <section class="panel card">
-    <div class="card-header">
-      <h2 class="heading subtitle">Add File Information</h2>
-      <h3 class="text file-list-heading">Files</h3>
-    </div>
-    <div class="card-body scrollable">
-      <div class="scroll-content">
-        <ul class="file-list"></ul>
-      </div>
-    </div>
-    <div class="card-footer">
-      <div class="error-message"></div>
-      <button class="continue-btn primary" autocomplete="false">Continue</button>
-    </div>
-  </section>
-  <section class="panel scrollable">
-    <div class="file-detail-list scroll-content"></div>
-  </section>
-</template>
-<template id="fileListItem">
-  <li class="file-list-item" data-file-name="">
-    <div class="file-info" role="button">
-      <div class="status"></div>
-      <div class="name"></div>
-      <sl-format-bytes class="size help-text" value=""></sl-format-bytes>
-      <button class="delete-btn icon-btn danger">
-        <sl-icon
-          class="icon"
-          src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg"></sl-icon>
-      </button>
-    </div>
-  </li>
-</template>
-<template id="fileDetailItem">
-  <section class="file-detail" data-file-name="">
-    <header class="file-detail-header">
-      <h4 class="heading subtitle name"></h4>
-      <button class="edit-btn icon-btn default">
-        <sl-icon
-          class="icon"
-          src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/pencil.svg"></sl-icon>
-      </button>
-    </header>
-    <form class="name-form field hidden" autocomplete="off">
-      <input class="name-input" value=""/>
-      <button type="submit" class="save-btn icon-btn secondary">
-        <sl-icon
-          class="icon"
-          src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-lg.svg"></sl-icon>
-      </button>
-    </form>
-    <label class="field">
-      <div class="label-text">Description</div>
-      <textarea placeholder="Add a short explanation of the file's contents"></textarea>
-    </label>
-  </section>
-</template>
-<template id="incompleteWarningScreen">
-  <section class="panel card incomplete-warning">
-    <div class="card-body incomplete-message">
-      <div>
-        <p class="heading">Some files didn’t upload properly</p>
-        <p class="text">Are you sure you want to continue?</p>
-        <p class="text">Incomplete uploads will not be present in the final website.</p>
-      </div>
-    </div>
-    <div class="card-footer">
-      <button class="back-btn default">Go Back</button>
-      <button class="continue-btn primary">Continue</button>
-    </div>
-  </section>
-</template>
-<template id="creatingSiteScreen">
-  <section class="panel card">
-    <div class="card-body upload-status-message">
-      <div>
-        <sl-spinner></sl-spinner>
-        <div class="heading">Creating Website</div>
-        <div class="site-status help-text">Uploading to IPFS...</div>
-      </div>
-    </div>
-  </section>
-</template>
-<template id="creatingSiteErrorScreen">
-  <section class="panel card">
-    <div class="card-body upload-status-message">
-      <div>
-        <p class="text">
-          Couldn't create website due to error:
-        </p>
-        <div class="error-message"></div>
-        <button class="retry-btn primary">Retry</button>
-      </div>
-    </div>
-    <div class="card-footer">
-      <button class="back-btn default">Go Back</button>
-    </div>
-  </section>
-</template>
-<template id="createSiteDoneScreen">
-  <section class="panel card">
-    <div class="card-body upload-status-message">
-      <div>
-        <div class="heading subtitle">Success!</div>
-        <p class="text">Your archive is available at:</p>
-        <div class="heading">
-          <a class="site-url primary" href="#" target="_blank" rel="noreferrer noopener"></a>
+          <div class="file-upload-container">
+            <label id="dropzone" class="file-drag-drop">
+              <svg
+                class="file-upload-border"
+                xmlns="http://www.w3.org/2000/svg"
+                text-rendering="geometricPrecision"
+                shape-rendering="geometricPrecision"
+                height="100%"
+                width="100%"
+                viewbox="0 0 460 468">
+                <rect
+                  class="animate-border"
+                  transform="translate(2,2)"
+                  stroke="#0366d6"
+                  width="456"
+                  height="464"
+                  fill="none"
+                  stroke-width="4"
+                  stroke-linecap="round"
+                  rx="8"
+                  stroke-dasharray="24 24"
+                  stroke-dashoffset="0"/>
+              </svg>
+              <sl-animation name="pulse" iterations="1" playback-rate="2">
+                <div class="dropzone-content">
+                  <div class="dropzone-label">
+                    <p class="error-message hidden">
+                      No valid web archive files selected.
+                    </p>
+                    Click here or drop some files.
+                  </div>
+                  <p class="help-text">
+                    Multiple .wacz files will be combined into a single browsable collection, 100MB size limit per file.
+                  </p>
+                  <input type="file" id="fileInput" class="file-input" multiple accept=".wacz,.warc"/>
+                </div>
+              </sl-animation>
+            </label>
+          </div>
         </div>
-        <div>
-          <button class="restart-btn primary">Create Another</button>
+      </main>
+    </div>
+    <div id="debug" class="hidden">
+      <details>
+        <summary>DEBUG: Past uploads:</summary>
+        <section id="resultzone"></section>
+      </details>
+      <details>
+        <summary>DEBUG: status log</summary>
+        <section id="statuslog"></section>
+      </details>
+    </div>
+    <template id="uploadProgressScreen">
+      <section class="panel card">
+        <div class="card-header">
+          <h2 class="heading subtitle">Add File Information</h2>
+          <h3 class="text file-list-heading">Files</h3>
         </div>
-      </div>
-    </div>
-  </section>
-</template>
-<template id="settingsPanel">
-  <section class="panel card">
-    <div class="card-header">
-      <h3 class="heading subtitle">Back-End Settings</h3>
-    </div>
-    <div class="card-body scrollable">
-      <form class="scroll-content">
+        <div class="card-body scrollable">
+          <div class="scroll-content">
+            <ul class="file-list"></ul>
+          </div>
+        </div>
+        <div class="card-footer">
+          <div class="error-message"></div>
+          <button class="continue-btn primary" autocomplete="false">Continue</button>
+        </div>
+      </section>
+      <section class="panel scrollable">
+        <div class="file-detail-list scroll-content"></div>
+      </section>
+    </template>
+    <template id="fileListItem">
+      <li class="file-list-item" data-file-name="">
+        <div class="file-info" role="button">
+          <div class="status"></div>
+          <div class="name"></div>
+          <sl-format-bytes class="size help-text" value=""></sl-format-bytes>
+          <button class="delete-btn icon-btn danger">
+            <sl-icon
+              class="icon"
+              src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/trash3.svg"></sl-icon>
+          </button>
+        </div>
+      </li>
+    </template>
+    <template id="fileDetailItem">
+      <section class="file-detail" data-file-name="">
+        <header class="file-detail-header">
+          <h4 class="heading subtitle name"></h4>
+          <button class="edit-btn icon-btn default">
+            <sl-icon
+              class="icon"
+              src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/pencil.svg"></sl-icon>
+          </button>
+        </header>
+        <form class="name-form field hidden" autocomplete="off">
+          <input class="name-input" value=""/>
+          <button type="submit" class="save-btn icon-btn secondary">
+            <sl-icon
+              class="icon"
+              src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/assets/icons/check-lg.svg"></sl-icon>
+          </button>
+        </form>
         <label class="field">
-          <div class="label-text">IPFS Backend</div>
-          <select>
-            <option value="">Webrecorder Default</option>
-          </select>
+          <div class="label-text">Description</div>
+          <textarea placeholder="Add a short explanation of the file's contents"></textarea>
         </label>
-        <label class="field">
-          <div class="label-text">Custom Web3.Storage Token</div>
-          <input placeholder="[EXAMPLE]"/>
-        </label>
-        <label class="field">
-          <div class="label-text">Custom Estuary Token</div>
-          <input placeholder="[EXAMPLE]"/>
-        </label>
-        <label class="field">
-          <div class="label-text">Personal Kubo Daemon URL</div>
-          <input placeholder="[EXAMPLE]"/>
-        </label>
-      </form>
-    </div>
-    <div class="card-footer">
-      <button class="default">Cancel</button>
-      <button class="primary">Save Settings</button>
-    </div>
-  </section>
-</template>
-<script type="module" src="./vendor.js"></script>
-<script type="module" src="./bundle.js"></script>
-</body>
+      </section>
+    </template>
+    <template id="incompleteWarningScreen">
+      <section class="panel card incomplete-warning">
+        <div class="card-body incomplete-message">
+          <div>
+            <p class="heading">Some files didn’t upload properly</p>
+            <p class="text">Are you sure you want to continue?</p>
+            <p class="text">Incomplete uploads will not be present in the final website.</p>
+          </div>
+        </div>
+        <div class="card-footer">
+          <button class="back-btn default">Go Back</button>
+          <button class="continue-btn primary">Continue</button>
+        </div>
+      </section>
+    </template>
+    <template id="creatingSiteScreen">
+      <section class="panel card">
+        <div class="card-body upload-status-message">
+          <div>
+            <sl-spinner></sl-spinner>
+            <div class="heading">Creating Website</div>
+            <div class="site-status help-text">Uploading to IPFS...</div>
+          </div>
+        </div>
+      </section>
+    </template>
+    <template id="creatingSiteErrorScreen">
+      <section class="panel card">
+        <div class="card-body upload-status-message">
+          <div>
+            <p class="text">
+              Couldn't create website due to error:
+            </p>
+            <div class="error-message"></div>
+            <button class="retry-btn primary">Retry</button>
+          </div>
+        </div>
+        <div class="card-footer">
+          <button class="back-btn default">Go Back</button>
+        </div>
+      </section>
+    </template>
+    <template id="createSiteDoneScreen">
+      <section class="panel card">
+        <div class="card-body upload-status-message">
+          <div>
+            <div class="heading subtitle">Success!</div>
+            <p class="text">Your archive is available at:</p>
+            <div class="heading">
+              <a class="site-url primary" href="#" target="_blank" rel="noreferrer noopener"></a>
+            </div>
+            <div>
+              <button class="restart-btn primary">Create Another</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </template>
+    <template id="settingsPanel">
+      <section class="panel card">
+        <div class="card-header">
+          <h3 class="heading subtitle">Back-End Settings</h3>
+        </div>
+        <div class="card-body scrollable">
+          <form class="scroll-content">
+            <label class="field">
+              <div class="label-text">IPFS Backend</div>
+              <select>
+                <option value="">Webrecorder Default</option>
+              </select>
+            </label>
+            <label class="field">
+              <div class="label-text">Custom Web3.Storage Token</div>
+              <input placeholder="[EXAMPLE]"/>
+            </label>
+            <label class="field">
+              <div class="label-text">Custom Estuary Token</div>
+              <input placeholder="[EXAMPLE]"/>
+            </label>
+            <label class="field">
+              <div class="label-text">Personal Kubo Daemon URL</div>
+              <input placeholder="[EXAMPLE]"/>
+            </label>
+          </form>
+        </div>
+        <div class="card-footer">
+          <button class="default">Cancel</button>
+          <button class="primary">Save Settings</button>
+        </div>
+      </section>
+    </template>
+    <script type="module" src="./vendor.js"></script>
+    <script type="module" src="./bundle.js"></script>
+  </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "concurrently": "^7.4.0",
         "dotenv": "^16.0.3",
         "esbuild": "^0.15.10",
+        "rimraf": "^3.0.2",
         "standard": "^17.0.0",
         "wait-on": "^6.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "standard --fix",
     "build": "NODE_ENV=production node scripts/build.js",
     "serve": "wds --node-resolve --open --watch",
-    "dev": "rm bundle.js && concurrently \"node scripts/build.js --watch\" \"wait-on bundle.js && npm run serve\""
+    "dev": "rimraf bundle.js && concurrently \"node scripts/build.js --watch\" \"wait-on bundle.js && npm run serve\""
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
     "concurrently": "^7.4.0",
     "dotenv": "^16.0.3",
     "esbuild": "^0.15.10",
+    "rimraf": "^3.0.2",
     "standard": "^17.0.0",
     "wait-on": "^6.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "standard --fix",
     "build": "NODE_ENV=production node scripts/build.js",
     "serve": "wds --node-resolve --open --watch",
-    "dev": "concurrently \"npm run build -- --watch\" \"wait-on bundle.js && npm run serve\""
+    "dev": "concurrently \"node scripts/build.js --watch\" \"wait-on bundle.js && npm run serve\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "standard --fix",
     "build": "NODE_ENV=production node scripts/build.js",
     "serve": "wds --node-resolve --open --watch",
-    "dev": "concurrently \"node scripts/build.js --watch\" \"wait-on bundle.js && npm run serve\""
+    "dev": "rm bundle.js && concurrently \"node scripts/build.js --watch\" \"wait-on bundle.js && npm run serve\""
   },
   "repository": {
     "type": "git",

--- a/styles.css
+++ b/styles.css
@@ -344,6 +344,20 @@ a.secondary:active {
   padding: 1.5rem;
 }
 
+.file-input-label {
+  display: inline-block;
+  color: var(--sl-color-blue-500);
+  font-size: var(--sl-font-size-small);
+  font-weight: 600;
+  cursor: pointer;
+  padding: .5rem;
+  transition: color .15s;
+}
+
+.file-input-label:hover {
+  color: var(--sl-color-blue-400);
+}
+
 .file-list-heading {
   margin: 0;
   padding-bottom: 0.125rem;
@@ -468,7 +482,7 @@ a.secondary:active {
   color: var(--sl-color-success-600);
 }
 
-#fileInput {
+.file-input {
   display: none;
 }
 

--- a/ui.js
+++ b/ui.js
@@ -279,6 +279,26 @@ export class App {
     wrapper.addEventListener('uploadsiteerror', (evt) =>
       this.stateService.send('UPLOAD_SITE_ERROR', evt)
     )
+
+    window.setTimeout(() => {
+      this.stateService.send('FILE_INPUT_CHANGE', { fileList: [
+        new File([], 'fake', { type: 'application/wacz' }),
+        new File([], 'fake1', { type: 'application/wacz' }),
+        new File([], 'fake2', { type: 'application/wacz' }),
+        new File([], 'fake3', { type: 'application/wacz' }),
+        new File([], 'fake4', { type: 'application/wacz' }),
+        new File([], 'fake5', { type: 'application/wacz' }),
+        new File([], 'fake6', { type: 'application/wacz' }),
+        new File([], 'fake7', { type: 'application/wacz' }),
+        new File([], 'fake8', { type: 'application/wacz' }),
+        new File([], 'fake9', { type: 'application/wacz' }),
+        new File([], 'fake10', { type: 'application/wacz' }),
+        new File([], 'fake11', { type: 'application/wacz' }),
+        new File([], 'fake12', { type: 'application/wacz' }),
+        new File([], 'fake13', { type: 'application/wacz' }),
+        new File([], 'fake14', { type: 'application/wacz' }),
+      ] })
+    }, 500)
   }
 
   renderInitial() {

--- a/ui.js
+++ b/ui.js
@@ -282,38 +282,43 @@ export class App {
   }
 
   renderInitial() {
-    window.dropzone.addEventListener('drag', (e) => {
-      e.preventDefault()
-      e.stopPropagation()
+    Array.from(document.querySelectorAll('.file-drag-drop')).forEach(elem => {
+      elem.addEventListener('drag', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      })
+      elem.addEventListener('dragstart', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      })
+      elem.addEventListener('dragend', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      })
+      elem.addEventListener('dragleave', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      })
+      elem.addEventListener('dragover', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      })
+      elem.addEventListener('dragenter', (e) => {
+        if (!elem.contains(e.relatedTarget)) {
+          elem.querySelector('sl-animation').setAttribute('play', true)
+        }
+      })
+      elem.addEventListener('drop', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        this.stateService.send('FILE_INPUT_CHANGE', { fileList: e.dataTransfer.files })
+      })
     })
-    window.dropzone.addEventListener('dragstart', (e) => {
-      e.preventDefault()
-      e.stopPropagation()
-    })
-    window.dropzone.addEventListener('dragend', (e) => {
-      e.preventDefault()
-      e.stopPropagation()
-    })
-    window.dropzone.addEventListener('dragleave', (e) => {
-      e.preventDefault()
-      e.stopPropagation()
-    })
-    window.dropzone.addEventListener('dragover', (e) => {
-      e.preventDefault()
-      e.stopPropagation()
-    })
-    window.dropzone.addEventListener('dragenter', (e) => {
-      if (!window.dropzone.contains(e.relatedTarget)) {
-        window.dropzone.querySelector('sl-animation').setAttribute('play', true)
-      }
-    })
-    window.dropzone.addEventListener('drop', (e) => {
-      e.preventDefault()
-      e.stopPropagation()
-      this.stateService.send('FILE_INPUT_CHANGE', { fileList: e.dataTransfer.files })
-    })
-    window.fileInput.addEventListener('change', (e) => {
-      this.stateService.send('FILE_INPUT_CHANGE', { fileList: e.target.files })
+
+    Array.from(document.querySelectorAll('.file-input')).forEach(elem => {
+      elem.addEventListener('change', (e) => {
+        this.stateService.send('FILE_INPUT_CHANGE', { fileList: e.target.files })
+      })
     })
   }
 
@@ -494,7 +499,7 @@ export class App {
   }
 
   renderNoValidFiles() {
-    const dropzone = this.appRoot.querySelector('#dropzone')
+    const dropzone = this.appRoot.querySelector('.file-drag-drop')
     dropzone.classList.add('has-error')
     dropzone.querySelector('.error-message').classList.remove('hidden')
   }


### PR DESCRIPTION
Allow users to choose additional files after the initial selection. Resolves https://github.com/webrecorder/wacz-uploader/issues/14

Also added includes some small dev server improvements that I'll comment on, can be pulled out into a separate PR if that's easier.

### Manual testing
1. Run app with `npm run dev`
2. Choose files with drag/drop or click
3. Click "Add more files" and select files. Verify files are shown in file list
4. Try to add a file that's already been added. Verify file list only contains one instance of the file
5. Try removing and adding a file. Verify file list updates as expected

### Screenshots
<img width="473" alt="Screen Shot 2022-11-09 at 10 14 33 AM" src="https://user-images.githubusercontent.com/4672952/200883438-01278b5f-7270-4a51-895b-e7de614dc5e0.png">

#### Opinions
UI design: I went with the quickest option for selecting more files so drag/drop isn't enabled in this view (cc: @Shrinks99)